### PR TITLE
#7 #11 #13 버그 수정

### DIFF
--- a/src/main/java/com/chatforyou/io/config/RedisConfig.java
+++ b/src/main/java/com/chatforyou/io/config/RedisConfig.java
@@ -162,7 +162,7 @@ public class RedisConfig {
                 .addField(new TextField("sessionId"))
                 .addField(new TextField("creator").noStem())
                 .addField(new TextField("roomName").noStem())
-                .addField(new Field("currentTime", FieldType.NUMERIC));
+                .addField(new Field("createDate", FieldType.NUMERIC));
 
         // User 인덱스 스키마 정의
         Schema userSchema = new Schema()

--- a/src/main/java/com/chatforyou/io/controller/ChatRoomController.java
+++ b/src/main/java/com/chatforyou/io/controller/ChatRoomController.java
@@ -201,13 +201,8 @@ public class ChatRoomController {
             @PathVariable("sessionId") String sessionId,
             @RequestBody ChatRoomInVo chatRoomInVo) throws BadRequestException {
         jwtService.verifyAccessToken(bearerToken);
-        Boolean result = chatRoomService.checkRoomPassword(sessionId, chatRoomInVo.getPwd());
-        if (Boolean.FALSE.equals(result)) {
-            throw new RuntimeException("Unknown Server Exception");
-        }
-
         Map<String, Object> response = new HashMap<>();
-        response.put("result", "success");
+        response.put("result", chatRoomService.checkRoomPassword(sessionId, chatRoomInVo.getPwd()));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/chatforyou/io/entity/ChatRoom.java
+++ b/src/main/java/com/chatforyou/io/entity/ChatRoom.java
@@ -52,6 +52,8 @@ public class ChatRoom {
 
     @Column(name = "CREATE_DATE", nullable = false, updatable = false)
     private Long createDate;
+    @Column(name = "UPDATE_DATE", nullable = true, updatable = true)
+    private Long updateDate;
 
     // TODO 삭제 필요한지 확인
     @Deprecated
@@ -59,6 +61,7 @@ public class ChatRoom {
     private Set<OpenViduInfo> openViduInfos;
 
     public static ChatRoom of(ChatRoomInVo chatRoomInVo, User user){
+        long currentTime = new Date().getTime();
         return ChatRoom.builder()
                 .user(user)
                 .sessionId(UUID.randomUUID().toString())
@@ -69,7 +72,8 @@ public class ChatRoom {
                 .useRtc(Objects.isNull(chatRoomInVo.getUseRtc()) ? false : chatRoomInVo.getUseRtc())
                 .desc(chatRoomInVo.getDesc())
                 .maxUserCount(chatRoomInVo.getMaxUserCount())
-                .createDate(new Date().getTime())
+                .createDate(currentTime)
+                .updateDate(currentTime)
                 .build();
     }
 
@@ -86,6 +90,7 @@ public class ChatRoom {
                 .desc(StringUtil.isNullOrEmpty(chatRoomInVo.getDesc()) ? chatRoom.getDesc() : chatRoomInVo.getDesc())
                 .maxUserCount(chatRoomInVo.getMaxUserCount() == 0 ? chatRoom.getMaxUserCount() : chatRoomInVo.getMaxUserCount())
                 .createDate(chatRoom.getCreateDate())
+                .updateDate(new Date().getTime())
                 .build();
     }
 

--- a/src/main/java/com/chatforyou/io/models/in/ChatRoomInVo.java
+++ b/src/main/java/com/chatforyou/io/models/in/ChatRoomInVo.java
@@ -20,9 +20,13 @@ public class ChatRoomInVo {
     private Boolean useRtc;
     private String desc;
     private Integer maxUserCount;
+    private Long createDate;
+    private Long updateDate;
 
-    public void setSessionIdAndCreator(String sessionId, String creator){
+    public void setRequiredRoomInfo(String sessionId, String creator, Long createDate, Long updateDate){
         this.sessionId = sessionId;
         this.creator = creator;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
     }
 }

--- a/src/main/java/com/chatforyou/io/models/in/ChatRoomInVo.java
+++ b/src/main/java/com/chatforyou/io/models/in/ChatRoomInVo.java
@@ -3,6 +3,9 @@ package com.chatforyou.io.models.in;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
+import java.util.Date;
+import java.util.Objects;
+
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
@@ -28,5 +31,20 @@ public class ChatRoomInVo {
         this.creator = creator;
         this.createDate = createDate;
         this.updateDate = updateDate;
+    }
+
+    public static ChatRoomInVo ofUpdate(ChatRoomInVo chatRoomInVo, ChatRoomInVo newChatRoomInVo){
+        return ChatRoomInVo.builder()
+                .sessionId(chatRoomInVo.getSessionId())
+                .userIdx(chatRoomInVo.getUserIdx())
+                .roomName(Objects.isNull(newChatRoomInVo.getRoomName()) ? chatRoomInVo.getRoomName() : newChatRoomInVo.getRoomName())
+                .usePwd(Boolean.TRUE.equals(newChatRoomInVo.getUsePwd()))
+                .pwd(Objects.isNull(newChatRoomInVo.getPwd()) ? chatRoomInVo.getPwd() : newChatRoomInVo.getPwd())
+                .usePrivate(Boolean.TRUE.equals(newChatRoomInVo.getUsePrivate()))
+                .maxUserCount(Objects.isNull(newChatRoomInVo.getMaxUserCount()) ? chatRoomInVo.getMaxUserCount() : newChatRoomInVo.getMaxUserCount())
+                .desc(Objects.isNull(newChatRoomInVo.getDesc()) ? chatRoomInVo.getDesc() : newChatRoomInVo.getDesc())
+                .createDate(chatRoomInVo.getCreateDate())
+                .updateDate(new Date().getTime())
+                .build();
     }
 }

--- a/src/main/java/com/chatforyou/io/models/out/ChatRoomOutVo.java
+++ b/src/main/java/com/chatforyou/io/models/out/ChatRoomOutVo.java
@@ -13,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
-@JsonIgnoreProperties({"pwd"})
+@JsonIgnoreProperties({"pwd", "currentUserCount", "userList"})
 public class ChatRoomOutVo implements Serializable {
     private static final long serialVersionUID = 1L;
     private Long userIdx;
@@ -25,7 +25,7 @@ public class ChatRoomOutVo implements Serializable {
     private Boolean usePrivate;
     private Boolean useRtc;
     @Setter
-    private int currentUserCount;
+    private Integer currentUserCount;
     private Integer maxUserCount;
     @Setter
     private List<UserOutVo> userList;
@@ -60,6 +60,21 @@ public class ChatRoomOutVo implements Serializable {
                 .currentUserCount(currentUserCount)
                 .maxUserCount(chatRoomInVo.getMaxUserCount())
                 .userList(list)
+                .createDate(chatRoomInVo.getCreateDate())
+                .updateDate(chatRoomInVo.getUpdateDate())
+                .build();
+    }
+
+    public static ChatRoomOutVo of(ChatRoomInVo chatRoomInVo){
+        return ChatRoomOutVo.builder()
+                .sessionId(chatRoomInVo.getSessionId())
+                .creator(chatRoomInVo.getCreator())
+                .userIdx(chatRoomInVo.getUserIdx())
+                .roomName(chatRoomInVo.getRoomName())
+                .usePwd(chatRoomInVo.getUsePwd())
+                .usePrivate(chatRoomInVo.getUsePrivate())
+                .useRtc(chatRoomInVo.getUseRtc())
+                .maxUserCount(chatRoomInVo.getMaxUserCount())
                 .createDate(chatRoomInVo.getCreateDate())
                 .updateDate(chatRoomInVo.getUpdateDate())
                 .build();

--- a/src/main/java/com/chatforyou/io/models/out/ChatRoomOutVo.java
+++ b/src/main/java/com/chatforyou/io/models/out/ChatRoomOutVo.java
@@ -29,6 +29,8 @@ public class ChatRoomOutVo implements Serializable {
     private Integer maxUserCount;
     @Setter
     private List<UserOutVo> userList;
+    private Long createDate;
+    private Long updateDate;
 
     public static ChatRoomOutVo of(ChatRoom chatRoom, int currentUserCount){
         return ChatRoomOutVo.builder()
@@ -41,6 +43,8 @@ public class ChatRoomOutVo implements Serializable {
                 .useRtc(chatRoom.getUseRtc())
                 .currentUserCount(currentUserCount)
                 .maxUserCount(chatRoom.getMaxUserCount())
+                .createDate(chatRoom.getCreateDate())
+                .updateDate(chatRoom.getUpdateDate())
                 .build();
     }
 
@@ -56,6 +60,8 @@ public class ChatRoomOutVo implements Serializable {
                 .currentUserCount(currentUserCount)
                 .maxUserCount(chatRoomInVo.getMaxUserCount())
                 .userList(list)
+                .createDate(chatRoomInVo.getCreateDate())
+                .updateDate(chatRoomInVo.getUpdateDate())
                 .build();
     }
 }

--- a/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
@@ -66,7 +66,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         // 5. 새로운 room 저장
         ThreadUtils.runTask(() -> {
             try{
-                chatRoomInVo.setSessionIdAndCreator(chatRoomEntity.getSessionId(), userEntity.getNickName());
+                chatRoomInVo.setRequiredRoomInfo(chatRoomEntity.getSessionId(), userEntity.getNickName(), chatRoomEntity.getCreateDate(), chatRoomEntity.getUpdateDate());
                 redisUtils.createChatRoomJob(chatRoomEntity.getSessionId(), chatRoomInVo, openViduRoom);
                 return true;
             } catch (Exception e){

--- a/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
@@ -26,6 +26,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -196,11 +198,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     @Override
     public Boolean checkRoomPassword(String sessionId, String pwd) throws BadRequestException {
-        ChatRoomOutVo chatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomOutVo.class);
-        if (Boolean.FALSE.equals(chatRoom.getUsePwd())) {
-            throw new BadRequestException("This room does not require a password");
+        ChatRoomInVo chatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomInVo.class);
+        if (Objects.isNull(pwd)) {
+            throw new BadRequestException("This room require a password");
         }
-        if (chatRoom.getPwd().equals(pwd)) {
+        if (!chatRoom.getPwd().equals(pwd)) {
             throw new BadRequestException("Invalid password");
         }
         return true;
@@ -208,30 +210,29 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     @Override
     @Transactional
-    public ChatRoomOutVo updateChatRoom(String sessionId, ChatRoomInVo chatRoomInVo, JwtPayload jwtPayload) throws BadRequestException {
+    public ChatRoomOutVo updateChatRoom(String sessionId, ChatRoomInVo newChatRoomInVo, JwtPayload jwtPayload) throws BadRequestException {
         ChatRoom chatRoomEntity = chatRoomRepository.findChatRoomBySessionId(sessionId)
                 .orElseThrow(() -> new EntityNotFoundException("Can not find ChatRoom"));
 
-        ChatRoom newChatRoomEntity = ChatRoom.ofUpdate(chatRoomEntity, chatRoomInVo);
+        ChatRoom newChatRoomEntity = ChatRoom.ofUpdate(chatRoomEntity, newChatRoomInVo);
         chatRoomRepository.saveAndFlush(newChatRoomEntity);
 
-        ChatRoomOutVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomOutVo.class);
+        ChatRoomInVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomInVo.class);
         if (!Objects.equals(redisChatRoom.getUserIdx(), jwtPayload.getIdx())) {
             throw new BadRequestException("The user ID in the token does not match the user ID provided in the chat room information.");
         }
 
-        int currentUserCount = redisUtils.getUserCount(sessionId);
-        ChatRoomOutVo chatRoomOutVo = ChatRoomOutVo.of(newChatRoomEntity, currentUserCount);
-        redisUtils.setObjectOpsHash(sessionId, DataType.CHATROOM, chatRoomOutVo);
+        ChatRoomInVo chatRoomInVo = ChatRoomInVo.ofUpdate(redisChatRoom, newChatRoomInVo);
+        redisUtils.setObjectOpsHash(sessionId, DataType.CHATROOM, chatRoomInVo);
 
-        return chatRoomOutVo;
+        return ChatRoomOutVo.of(chatRoomInVo);
     }
 
     @Override
     @Transactional
     public boolean deleteChatRoom(String sessionId, JwtPayload jwtPayload, boolean isSystem) throws BadRequestException {
         if (!isSystem) {
-            ChatRoomOutVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomOutVo.class);
+            ChatRoomInVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomInVo.class);
             if (!Objects.equals(redisChatRoom.getUserIdx(), jwtPayload.getIdx())) {
                 throw new BadRequestException("The user ID in the token does not match the user ID provided in the chat room information.");
             }

--- a/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
@@ -54,6 +54,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         User userEntity = userRepository.findUserByIdx(chatRoomInVo.getUserIdx())
                 .orElseThrow(() -> new EntityNotFoundException("can not find user"));
 
+        // 중복 방 이름 확인
+        if (redisUtils.searchDuplicateRoomName(chatRoomInVo.getRoomName())) {
+            // 예외처리
+            throw new BadRequestException("Same RoomName Already Exist");
+        }
+
         // 2. entity 로 변환
         ChatRoom chatRoomEntity = ChatRoom.of(chatRoomInVo, userEntity);
 

--- a/src/main/java/com/chatforyou/io/utils/RedisUtils.java
+++ b/src/main/java/com/chatforyou/io/utils/RedisUtils.java
@@ -275,7 +275,7 @@ public class RedisUtils {
         masterTemplate.opsForHash().put(redisKey, "sessionId", sessionId);
         masterTemplate.opsForHash().put(redisKey, "creator", chatRoomInVo.getCreator());
         masterTemplate.opsForHash().put(redisKey, "roomName", chatRoomInVo.getRoomName());
-        masterTemplate.opsForHash().put(redisKey, "currentTime", new Date().getTime());
+        masterTemplate.opsForHash().put(redisKey, "createDate", chatRoomInVo.getCreateDate());
         // OpenVidu 객체 저장
         masterTemplate.opsForHash().put(redisKey, DataType.OPENVIDU.getType(), openViduDto);
     }
@@ -411,7 +411,7 @@ public class RedisUtils {
                 searchOptions = new SearchOptions()
                         .page(pageNum * pageSize, pageSize)  // 페이지 설정
                         .returnFields("sessionId")  // sessionId 필드만 반환
-                        .sort(new SortBy("currentTime", SortOrder.DESC));  // currentTime 기준 내림차순 정렬
+                        .sort(new SortBy("createDate", SortOrder.DESC));  // createDate 기준 내림차순 정렬
                 break;
 
             case LOGIN_USER:

--- a/src/main/java/com/chatforyou/io/utils/RedisUtils.java
+++ b/src/main/java/com/chatforyou/io/utils/RedisUtils.java
@@ -435,6 +435,21 @@ public class RedisUtils {
         return documents;
     }
 
+    public boolean searchDuplicateRoomName(String keyword) {
+        // searchType 에 맞춰 indexName 을 가져옴
+        RediSearch rediSearch = rediSearchClient.getRediSearch(SearchType.CHATROOM.getIndexName());
+
+        SearchOptions searchOptions = new SearchOptions()
+                .returnFields("roomName");  // sessionId 필드만 반환
+
+        long count = rediSearch.search(
+                "@roomName:*" + keyword + "*",
+                searchOptions
+        ).getTotal();
+
+        return count > 0;
+    }
+
     public void saveLoginUser(UserOutVo user) {
         // redisKey = user:userIdx
         String redisKey = "user:" + user.getIdx();


### PR DESCRIPTION
각각 아래와 같이 기능 개발 및 버그 수정 완료했습니다.


# #7 채팅방 createDate, updateDate 추가  
- 기존에는 채팅방 저장 시 createDate 와 updateDate 를 모두 저장 X   
- 해당 부분 확인 후 저장 및 조회 가능하도록 개발  

# #11 중복 방 생성 가능한 버그  
[원인]
-  방 생성 시 roomName 의 중복체크하는 로직 누락  

[수정]
- 방 생성 시 roomName 확인해서 에러 발생 할 수 있도록 수정   

# #13 채팅방 업데이트 및 패스워드 확인 api 에러
- 채팅방 업데이트 및 패스워드 확인 api 사용 시 에러 발생  

[원인]
- 채팅방 업데이트 및 패스워드 확인 시 redis 조회 후 return 받는 객체가 저장 시 사용하는 객체와 달라 casting Exception 발생  

[수정]
- return 객체와 save 객체가 동일하도록 변경 :: ChatRoomOutVo -> ChatRoomInVo

## Sourcery에 의한 요약

채팅방 생성, 중복 및 API 오류와 관련된 버그를 수정하고 생성 및 업데이트에 대한 타임스탬프와 함께 채팅방 데이터를 향상시킵니다.

버그 수정:
- 생성 전에 기존 방 이름을 확인하여 중복 채팅방이 생성될 수 있는 문제를 수정합니다.
- 검색 및 저장 간의 일관된 객체 유형을 보장하여 채팅방 업데이트 및 비밀번호 확인 API에서 캐스팅 예외를 해결합니다.

향상된 기능:
- 생성 및 수정 시간을 추적하기 위해 채팅방에 createDate 및 updateDate 필드를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix bugs related to chat room creation, duplication, and API errors, and enhance chat room data with timestamps for creation and updates.

Bug Fixes:
- Fix the issue where duplicate chat rooms could be created by adding a check for existing room names before creation.
- Resolve casting exceptions in chat room update and password verification APIs by ensuring consistent object types between retrieval and storage.

Enhancements:
- Add createDate and updateDate fields to chat rooms to track creation and modification times.

</details>