### PR TITLE
#21 유저목록조회 api 수정 :: 유저 목록과 로그인 유저 목록 조회 api 분리

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,8 @@ name: Docker CI/CD
 on:
   push:
     branches: [ "master", "infra/cicd-test" ]
-  pull_request:
-    branches: [ "master" ]
+#  pull_request:
+#    branches: [ "master" ]
 
 jobs:
   deploy:

--- a/src/main/java/com/chatforyou/io/controller/ChatRoomController.java
+++ b/src/main/java/com/chatforyou/io/controller/ChatRoomController.java
@@ -120,9 +120,13 @@ public class ChatRoomController {
             @RequestParam(value = "pageSize", required = false, defaultValue = "9") String pageSizeStr
     ) throws BadRequestException {
         Map<String, Object> response = new LinkedHashMap<>();
-        List<ChatRoomOutVo> chatRoomList = chatRoomService.getChatRoomList(keyword, Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr));
+        int pageNum = Integer.parseInt(pageNumStr);
+        int pageSize = Integer.parseInt(pageSizeStr);
+        List<ChatRoomOutVo> chatRoomList = chatRoomService.getChatRoomList(keyword, pageNum, pageSize);
         response.put("result", "success");
-        response.put("count", chatRoomList.size());
+        response.put("pageNum", pageNum == 0 ? 1 : pageNum);
+        response.put("pageSize", pageSize);
+        response.put("totalCount", chatRoomList.size());
         response.put("roomList", chatRoomList);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/chatforyou/io/controller/UserController.java
+++ b/src/main/java/com/chatforyou/io/controller/UserController.java
@@ -3,12 +3,10 @@ package com.chatforyou.io.controller;
 import com.chatforyou.io.models.ValidateType;
 import com.chatforyou.io.models.in.UserInVo;
 import com.chatforyou.io.models.in.UserUpdateVo;
-import com.chatforyou.io.models.out.ChatRoomOutVo;
 import com.chatforyou.io.models.out.UserOutVo;
 import com.chatforyou.io.services.AuthService;
 import com.chatforyou.io.services.JwtService;
 import com.chatforyou.io.services.UserService;
-import com.chatforyou.io.services.impl.JwtServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
 import org.springframework.http.HttpStatus;
@@ -108,7 +106,7 @@ public class UserController {
      * @return 로그인 유저 목록을 포함한 ResponseEntity
      * @throws BadRequestException 잘못된 요청일 경우 발생하는 예외
      */
-    @GetMapping("/list")
+    @GetMapping("/list/current")
     public ResponseEntity<Map<String, Object>> getLoginUserList(
             @RequestHeader("Authorization") String bearerToken,
             @RequestParam(value = "keyword", required = false) String keyword,
@@ -117,9 +115,42 @@ public class UserController {
     ) throws BadRequestException {
         jwtService.verifyAccessToken(bearerToken);
         Map<String, Object> response = new LinkedHashMap<>();
-        List<UserOutVo> userList = userService.getUserList(keyword, Integer.parseInt(pageNumStr), Integer.parseInt(pageSizeStr));
+        int pageNum = Integer.parseInt(pageNumStr);
+        int pageSize = Integer.parseInt(pageSizeStr);
+        List<UserOutVo> userList = userService.getLoginUserList(keyword, pageNum, pageSize);
         response.put("result", "success");
-        response.put("count", userList.size());
+        response.put("totalCount", userList.size());
+        response.put("pageNum", pageNum == 0 ? 1 : pageNum);
+        response.put("pageSize", pageSize);
+        response.put("userList", userList);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * 전체 유저 목록 조회
+     *
+     * @param keyword 검색 키워드 (선택 사항)
+     * @param pageNumStr 페이지 번호 (기본값 0)
+     * @param pageSizeStr 페이지 크기 (기본값 20)
+     * @return 로그인 유저 목록을 포함한 ResponseEntity
+     * @throws BadRequestException 잘못된 요청일 경우 발생하는 예외
+     */
+    @GetMapping("/list")
+    public ResponseEntity<Map<String, Object>> getUserList(
+            @RequestHeader("Authorization") String bearerToken,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "pageNum", required = false, defaultValue = "0") String pageNumStr,
+            @RequestParam(value = "pageSize", required = false, defaultValue = "20") String pageSizeStr
+    ) throws BadRequestException {
+        jwtService.verifyAccessToken(bearerToken);
+        Map<String, Object> response = new LinkedHashMap<>();
+        int pageNum = Integer.parseInt(pageNumStr);
+        int pageSize = Integer.parseInt(pageSizeStr);
+        List<UserOutVo> userList = userService.getUserList(keyword,  pageNum, pageSize);
+        response.put("result", "success");
+        response.put("totalCount", userList.size());
+        response.put("pageNum", pageNum == 0 ? 1 : pageNum);
+        response.put("pageSize", pageSize);
         response.put("userList", userList);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }

--- a/src/main/java/com/chatforyou/io/repository/UserRepository.java
+++ b/src/main/java/com/chatforyou/io/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.chatforyou.io.repository;
 
 import com.chatforyou.io.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -31,6 +33,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT CASE WHEN COUNT(u) > 0 THEN TRUE ELSE FALSE END FROM User u WHERE u.id = :id")
     boolean checkExistsById(@Param("id") String id);
+
+    @Query("SELECT u FROM User u WHERE u.nickName LIKE %:keyword% OR u.id LIKE %:keyword%")
+    Page<User> searchUserListByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("SELECT u FROM User u")
+    Page<User> searchUserList(@Param("keyword") String keyword, Pageable pageable);
 
 //    @Query("SELECT u from User u join Friend f on u.idx = f.friendIdx where f.userIdx=:idx")
 //    List<User> friendListByUserIdx(Long idx);

--- a/src/main/java/com/chatforyou/io/services/UserService.java
+++ b/src/main/java/com/chatforyou/io/services/UserService.java
@@ -1,12 +1,13 @@
 package com.chatforyou.io.services;
 
+import com.chatforyou.io.entity.User;
 import com.chatforyou.io.models.in.UserInVo;
 import com.chatforyou.io.models.in.UserUpdateVo;
 import com.chatforyou.io.models.out.UserOutVo;
 import org.apache.coyote.BadRequestException;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
-import java.util.Map;
 
 public interface UserService {
     UserOutVo findUserByIdx(Long idx);
@@ -16,6 +17,7 @@ public interface UserService {
     UserOutVo updateUserPwd(UserUpdateVo user) throws BadRequestException;
     boolean deleteUser(UserInVo userInVO) throws BadRequestException;
 
+    List<UserOutVo> getLoginUserList(String keyword, int pageNum, int pageSize);
     List<UserOutVo> getUserList(String keyword, int pageNum, int pageSize);
     void getFriendInfo();
 

--- a/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.chatforyou.io.services.impl;
 
+import ch.qos.logback.core.util.StringUtil;
 import com.chatforyou.io.entity.User;
 import com.chatforyou.io.models.DataType;
 import com.chatforyou.io.models.RedisIndex;
@@ -16,6 +17,9 @@ import io.github.dengliming.redismodule.redisearch.index.Document;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.BadRequestException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
@@ -111,7 +115,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<UserOutVo> getUserList(String keyword, int pageNum, int pageSize) {
+    public List<UserOutVo> getLoginUserList(String keyword, int pageNum, int pageSize) {
         List<UserOutVo> userList = new ArrayList<>();
         pageNum = pageNum !=0 ? pageNum - 1 : pageNum;
             List<Document> documents = redisUtils.searchByKeyword(RedisIndex.LOGIN_USER, keyword, pageNum, pageSize);
@@ -125,6 +129,26 @@ public class UserServiceImpl implements UserService {
         }
 
         return userList;
+    }
+
+    @Override
+    public List<UserOutVo> getUserList(String keyword, int pageNum, int pageSize) {
+        PageRequest pageRequest = PageRequest.of(pageNum, pageSize, Sort.by("nickName").ascending());
+        Page<User> userPage;
+        if (StringUtil.isNullOrEmpty(keyword)) {
+            userPage = userRepository.searchUserList(keyword, pageRequest);
+        } else {
+            userPage = userRepository.searchUserListByKeyword(keyword, pageRequest);
+        }
+
+        if (userPage.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return userPage.getContent()
+                .stream()
+                .map(user -> UserOutVo.of(user, false))
+                .toList();
     }
 
     @Override

--- a/src/test/java/com/chatforyou/io/services/impl/UserServiceImplTest.java
+++ b/src/test/java/com/chatforyou/io/services/impl/UserServiceImplTest.java
@@ -8,18 +8,22 @@ import com.chatforyou.io.services.UserService;
 import com.chatforyou.io.utils.AuthUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
 class UserServiceImplTest {
-
+    Logger logger = LoggerFactory.getLogger(UserServiceImplTest.class);
     @Autowired
     private UserRepository repository;
 
@@ -65,5 +69,12 @@ class UserServiceImplTest {
         UserOutVo userOutVo = authService.getLoginUserInfo(id, passwd);
         System.out.println("userinfo ::: " + userOutVo.toString());
 
+    }
+
+    @Test
+    @DisplayName("전체 유저 리스트 확인")
+    void getUserList(){
+        List<UserOutVo> userList = userService.getUserList("sejon", 0, 20);
+        System.out.println("userlist ::: " + userList.toString());
     }
 }


### PR DESCRIPTION
1. 유저 목록과 로그인 유저 목록 조회 api 분리
2. 채팅방 목록 조회 시 응답 수정
3. github action 변경 : master 브렌치가 pull request 및 push 시점 -> push 시점(only)