### PR TITLE
#19 Github Action 으로 CI/CD 개발 with K8S with package

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build And Deploy K8S
     environment: chatforyou-back-env # 환경 지정
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
     env:
       KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
       K8S_NAMESPACE: chatforyou-io # Kubernetes 네임스페이스

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
-      IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
       K8S_NAMESPACE: chatforyou-io # Kubernetes 네임스페이스
       DEPLOYMENT_NAME: chatforyou-io # Deployment 이름
 
@@ -29,28 +28,31 @@ jobs:
           echo "${KUBE_CONFIG}" | base64 --decode > ${HOME}/.kube/config
           export KUBECONFIG=${HOME}/.kube/config
 
-      # 3. TIMESTAMP 생성 (한국 시간으로)
+      # 3. TIMESTAMP 생성 (한국 시간으로) && IMAGE_URI 로 이미지명:태크명 공통화
+      # IMAGE_URI = chatforyou-io/chatforyou-io-backend:시간
       - name: Generate TIMESTAMP in KST
         id: timestamp
         run: |
           export TZ=Asia/Seoul
-          echo "TIMESTAMP=$(date -d "${{ github.event.head_commit.timestamp }}" '+%Y%m%d%H%M%S')" >> $GITHUB_ENV
+          TIMESTAMP=$(date '+%Y%m%d%H%M%S')
+          echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+          echo "IMAGE_URI=ghcr.io/${{ github.repository_owner }}/chatforyou-io-backend:$TIMESTAMP" >> $GITHUB_ENV
 
       # 5. Docker 이미지 빌드 및 태그
       - name: Build Docker Image
         run: |
-          docker build --file Dockerfile -t ghcr.io/${{ github.repository_owner }}/chatforyou-io-backend:${{ env.TIMESTAMP }} .
+          docker build --file Dockerfile -t $IMAGE_URI .
 
       # 6. Docker 이미지 푸시 (GitHub Container Registry)
       - name: Push Docker Image to GitHub Packages
         run: |
           echo "${{ secrets.GIT_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          docker push ghcr.io/${{ github.repository_owner }}/chatforyou-io:${{ env.TIMESTAMP }}
+          docker push $IMAGE_URI
 
       # 7. Kubernetes 배포
       - name: Deploy to Kubernetes
         run: |
           kubectl set image deployment/$DEPLOYMENT_NAME \
-            chatforyou-container=$IMAGE_REPO:${{ env.TIMESTAMP }} \
+            chatforyou-container=$IMAGE_URI \
             -n $K8S_NAMESPACE
           kubectl rollout status deployment/$DEPLOYMENT_NAME -n $K8S_NAMESPACE

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -36,20 +36,16 @@ jobs:
           export TZ=Asia/Seoul
           echo "TIMESTAMP=$(date -d "${{ github.event.head_commit.timestamp }}" '+%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
-      #      # 4. Docker 로그인
-      #      - name: Login to Docker Registry
-      #        run: |
-      #          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login ${{ secrets.DOCKER_REGISTRY_URL }} -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-
       # 5. Docker 이미지 빌드 및 태그
       - name: Build Docker Image
         run: |
-          docker build --file Dockerfile -t $IMAGE_REPO:${{ env.TIMESTAMP }} .
+          docker build --file Dockerfile -t ghcr.io/${{ github.repository_owner }}/chatforyou-io:${{ env.TIMESTAMP }} .
 
-      # 6. Docker 이미지 푸시
-      - name: Push Docker Image
+      # 6. Docker 이미지 푸시 (GitHub Container Registry)
+      - name: Push Docker Image to GitHub Packages
         run: |
-          docker push $IMAGE_REPO:${{ env.TIMESTAMP }}
+          echo "${{ secrets.GIT_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          docker push ghcr.io/${{ github.repository_owner }}/chatforyou-io:${{ env.TIMESTAMP }}
 
       # 7. Kubernetes 배포
       - name: Deploy to Kubernetes

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,7 +39,7 @@ jobs:
       # 5. Docker 이미지 빌드 및 태그
       - name: Build Docker Image
         run: |
-          docker build --file Dockerfile -t ghcr.io/${{ github.repository_owner }}/chatforyou-io:${{ env.TIMESTAMP }} .
+          docker build --file Dockerfile -t ghcr.io/${{ github.repository_owner }}/chatforyou-io-backend:${{ env.TIMESTAMP }} .
 
       # 6. Docker 이미지 푸시 (GitHub Container Registry)
       - name: Push Docker Image to GitHub Packages

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,7 +46,7 @@ jobs:
       # 6. Docker 이미지 푸시 (GitHub Container Registry)
       - name: Push Docker Image to GitHub Packages
         run: |
-          echo "${{ secrets.GIT_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           docker push $IMAGE_URI
 
       # 7. Kubernetes 배포


### PR DESCRIPTION
github action 과 k8s 이후 docker registry 를 기존의 local docker registry 에서 github package 인 ghcr.io 로 변경

# 변경 사항
- IMAGE_REPO 삭제 및 IMAGE_URI 로 대체
- packages 에 이미지 push 시 github_token 사용

## Summary by Sourcery

Docker 레지스트리를 로컬 레지스트리에서 GitHub Packages (ghcr.io)로 전환합니다.

CI:
- GitHub Packages에 이미지를 푸시하기 위해 GitHub 토큰 사용.
- 이미지 이름과 태그를 표준화하기 위해 IMAGE_URI 사용.

배포:
- ghcr.io의 새 이미지를 사용하도록 Kubernetes 배포 업데이트.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the Docker registry from a local registry to GitHub Packages (ghcr.io).

CI:
- Use the GitHub token for pushing images to GitHub Packages.
- Use IMAGE_URI to standardize the image name and tag.

Deployment:
- Update the Kubernetes deployment to use the new image from ghcr.io.

</details>