### PR TITLE
#8 유저 삭제 api 개선

### DIFF
--- a/src/main/java/com/chatforyou/io/controller/UserController.java
+++ b/src/main/java/com/chatforyou/io/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.chatforyou.io.controller;
 
+import com.chatforyou.io.models.JwtPayload;
 import com.chatforyou.io.models.ValidateType;
 import com.chatforyou.io.models.in.UserInVo;
 import com.chatforyou.io.models.in.UserUpdateVo;
@@ -89,8 +90,8 @@ public class UserController {
     public ResponseEntity<Map<String, Object>> deleteUser(
             @RequestHeader("Authorization") String bearerToken,
             @RequestBody UserInVo user) throws BadRequestException {
-        jwtService.verifyAccessToken(bearerToken);
-        userService.deleteUser(user);
+        JwtPayload jwtPayload = jwtService.verifyAccessToken(bearerToken);
+        userService.deleteUser(user, jwtPayload);
         Map<String, Object> response = new HashMap<>();
         response.put("result", "success");
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/src/main/java/com/chatforyou/io/controller/UserController.java
+++ b/src/main/java/com/chatforyou/io/controller/UserController.java
@@ -37,9 +37,8 @@ public class UserController {
     public ResponseEntity<Map<String, Object>> getUserInfo(
             @RequestParam String id) {
         Map<String, Object> response = new HashMap<>();
-        UserOutVo userOutVo = userService.findUserById(id);
         response.put("result", "success");
-        response.put("userData", userOutVo);
+        response.put("userData", userService.findUserById(id));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -59,9 +58,8 @@ public class UserController {
     @PostMapping("/create")
     public ResponseEntity<Map<String, Object>> createUser(@RequestBody UserInVo user) throws BadRequestException {
         Map<String, Object> response = new HashMap<>();
-        UserOutVo userOutVo = userService.saveUser(user);
         response.put("result", "success");
-        response.put("userData", userOutVo);
+        response.put("userData", userService.saveUser(user));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -69,20 +67,20 @@ public class UserController {
     @PatchMapping("/update")
     public ResponseEntity<Map<String, Object>> updateUser(@RequestHeader("Authorization") String bearerToken,
                                                           @RequestBody UserUpdateVo userVo) throws BadRequestException {
-        jwtService.verifyAccessToken(bearerToken);
+        JwtPayload jwtPayload = jwtService.verifyAccessToken(bearerToken);
         Map<String, Object> response = new HashMap<>();
         response.put("result", "success");
-        response.put("userData", userService.updateUser(userVo));
+        response.put("userData", userService.updateUser(userVo, jwtPayload));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @PatchMapping("/update/pwd")
     public ResponseEntity<Map<String, Object>> updateUserPasswd(@RequestHeader("Authorization") String bearerToken,
                                                                 @RequestBody UserUpdateVo userVo) throws BadRequestException {
-        jwtService.verifyAccessToken(bearerToken);
+        JwtPayload jwtPayload = jwtService.verifyAccessToken(bearerToken);
         Map<String, Object> response = new HashMap<>();
         response.put("result", "success");
-        response.put("userData", userService.updateUserPwd(userVo));
+        response.put("userData", userService.updateUserPwd(userVo, jwtPayload));
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -96,7 +94,6 @@ public class UserController {
         response.put("result", "success");
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
-
 
     /**
      * 현재 로그인된 유저 목록 조회
@@ -138,14 +135,13 @@ public class UserController {
                 userService::getUserList);
     }
 
-
     /**
      * 사용자 리스트를 조회하기 위한 함수형 인터페이스.
      * keyword, pageNum, pageSize를 입력으로 받고, List<UserOutVo>를 반환
      */
     @FunctionalInterface
     private interface UserListFunction {
-        List<UserOutVo> apply(String keyword, int pageNum, int pageSize);
+        List<UserOutVo> execute(String keyword, int pageNum, int pageSize);
     }
 
     /**
@@ -169,7 +165,7 @@ public class UserController {
         int pageNum = Integer.parseInt(pageNumStr);
         int pageSize = Integer.parseInt(pageSizeStr);
 
-        List<UserOutVo> userList = userListFunction.apply(keyword, pageNum, pageSize);
+        List<UserOutVo> userList = userListFunction.execute(keyword, pageNum, pageSize);
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("result", "success");
         response.put("totalCount", userList.size());

--- a/src/main/java/com/chatforyou/io/entity/SocialUser.java
+++ b/src/main/java/com/chatforyou/io/entity/SocialUser.java
@@ -16,7 +16,7 @@ public class SocialUser {
     @Column(name = "IDX", nullable = false)
     private Long idx;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @OneToOne(fetch = FetchType.LAZY, optional = false, orphanRemoval = true)
     @JoinColumn(name = "USER_IDX", nullable = false)
     private User user;
 

--- a/src/main/java/com/chatforyou/io/services/UserService.java
+++ b/src/main/java/com/chatforyou/io/services/UserService.java
@@ -1,6 +1,7 @@
 package com.chatforyou.io.services;
 
 import com.chatforyou.io.entity.User;
+import com.chatforyou.io.models.JwtPayload;
 import com.chatforyou.io.models.in.UserInVo;
 import com.chatforyou.io.models.in.UserUpdateVo;
 import com.chatforyou.io.models.out.UserOutVo;
@@ -15,7 +16,7 @@ public interface UserService {
     UserOutVo saveUser(UserInVo user) throws BadRequestException;
     UserOutVo updateUser(UserUpdateVo user) throws BadRequestException;
     UserOutVo updateUserPwd(UserUpdateVo user) throws BadRequestException;
-    boolean deleteUser(UserInVo userInVO) throws BadRequestException;
+    void deleteUser(UserInVo userInVO, JwtPayload jwtPayload) throws BadRequestException;
 
     List<UserOutVo> getLoginUserList(String keyword, int pageNum, int pageSize);
     List<UserOutVo> getUserList(String keyword, int pageNum, int pageSize);

--- a/src/main/java/com/chatforyou/io/services/UserService.java
+++ b/src/main/java/com/chatforyou/io/services/UserService.java
@@ -14,10 +14,9 @@ public interface UserService {
     UserOutVo findUserByIdx(Long idx);
     UserOutVo findUserById(String id);
     UserOutVo saveUser(UserInVo user) throws BadRequestException;
-    UserOutVo updateUser(UserUpdateVo user) throws BadRequestException;
-    UserOutVo updateUserPwd(UserUpdateVo user) throws BadRequestException;
+    UserOutVo updateUser(UserUpdateVo user, JwtPayload jwtPayload) throws BadRequestException;
+    UserOutVo updateUserPwd(UserUpdateVo user, JwtPayload jwtPayload) throws BadRequestException;
     void deleteUser(UserInVo userInVO, JwtPayload jwtPayload) throws BadRequestException;
-
     List<UserOutVo> getLoginUserList(String keyword, int pageNum, int pageSize);
     List<UserOutVo> getUserList(String keyword, int pageNum, int pageSize);
     void getFriendInfo();

--- a/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
@@ -70,7 +70,11 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserOutVo updateUser(UserUpdateVo userUpdateVo) throws BadRequestException {
+    public UserOutVo updateUser(UserUpdateVo userUpdateVo, JwtPayload jwtPayload) throws BadRequestException {
+        if (!Objects.equals(userUpdateVo.getIdx(), jwtPayload.getIdx())) {
+            throw new BadRequestException("The user ID in the token does not match the user ID provided in the chat room information.");
+        }
+
         User user = userRepository.findUserByIdx(userUpdateVo.getIdx())
                 .orElseThrow(()->new EntityNotFoundException("can not find user"));
 
@@ -80,7 +84,10 @@ public class UserServiceImpl implements UserService {
 
     @Override
     @Transactional
-    public UserOutVo updateUserPwd(UserUpdateVo userUpdateVo) throws BadRequestException {
+    public UserOutVo updateUserPwd(UserUpdateVo userUpdateVo, JwtPayload jwtPayload) throws BadRequestException {
+        if (!Objects.equals(userUpdateVo.getIdx(), jwtPayload.getIdx())) {
+            throw new BadRequestException("The user ID in the token does not match the user ID provided in the chat room information.");
+        }
 
         User user = userRepository.findUserByIdx(userUpdateVo.getIdx())
                 .orElseThrow(()->new EntityNotFoundException("can not find user"));

--- a/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/UserServiceImpl.java
@@ -1,13 +1,16 @@
 package com.chatforyou.io.services.impl;
 
 import ch.qos.logback.core.util.StringUtil;
+import com.chatforyou.io.entity.SocialUser;
 import com.chatforyou.io.entity.User;
 import com.chatforyou.io.models.DataType;
+import com.chatforyou.io.models.JwtPayload;
 import com.chatforyou.io.models.RedisIndex;
 import com.chatforyou.io.models.ValidateType;
 import com.chatforyou.io.models.in.UserInVo;
 import com.chatforyou.io.models.in.UserUpdateVo;
 import com.chatforyou.io.models.out.UserOutVo;
+import com.chatforyou.io.repository.SocialRepository;
 import com.chatforyou.io.repository.UserRepository;
 import com.chatforyou.io.services.AuthService;
 import com.chatforyou.io.services.UserService;
@@ -21,6 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 
@@ -32,6 +36,7 @@ public class UserServiceImpl implements UserService {
 
     private final AuthService authService;
     private final RedisUtils redisUtils;
+    private final SocialRepository socialRepository;
 
     private final int MAX_FRIEND_USERS = 50;
 
@@ -64,6 +69,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public UserOutVo updateUser(UserUpdateVo userUpdateVo) throws BadRequestException {
         User user = userRepository.findUserByIdx(userUpdateVo.getIdx())
                 .orElseThrow(()->new EntityNotFoundException("can not find user"));
@@ -73,6 +79,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
     public UserOutVo updateUserPwd(UserUpdateVo userUpdateVo) throws BadRequestException {
 
         User user = userRepository.findUserByIdx(userUpdateVo.getIdx())
@@ -100,16 +107,21 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public boolean deleteUser(UserInVo userInVO) throws BadRequestException {
-        User user = userRepository.findUserById(userInVO.getId())
-                .orElseThrow(() -> new EntityNotFoundException("can not find user"));
-        if (!user.getPwd().equals(userInVO.getPwd())) {
-            throw new BadRequestException("does not match user pwd");
+    @Transactional
+    public void deleteUser(UserInVo userInVO, JwtPayload jwtPayload) throws BadRequestException {
+
+        if (!Objects.equals(userInVO.getIdx(), jwtPayload.getIdx())) {
+            throw new BadRequestException("The user ID in the token does not match the user ID provided in the chat room information.");
         }
-        int result = userRepository.deleteUserByIdxAndId(user.getIdx(), user.getId());
-        if (result > 0) {
-            return true;
-        } else {
+
+        User user = userRepository.findUserByIdx(userInVO.getIdx())
+                .orElseThrow(() -> new EntityNotFoundException("can not find user"));
+
+        try {
+            // 소셜 유저의 경우 cascade 설정이 되어있어 user 삭제 후 함께 삭제처리
+            userRepository.delete(user);
+
+        } catch (Exception e) {
             throw new BadRequestException("can not delete user");
         }
     }


### PR DESCRIPTION
#8 유저 삭제 api 개선

1. body 개선
- body 부분을 userId 와 pwd 모두 받는 것에서 idx 만 받아 처리하도록 수정
2. 유저 삭제 개선
- 일반 유저 삭제 시 user 테이블에서 삭제
- 소셜 유저 삭제 시 user & socialUser 테이블 모두 삭제
 