### PR TITLE
#10 채팅방 RDB 저장 로직 삭제

### DIFF
--- a/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
@@ -23,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.coyote.BadRequestException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -40,7 +39,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     private final SseService sseService;
 
     @Override
-    @Transactional // 에러가 발생할 시 rollback 될 수 있도록 @Transactional 사용
     public ChatRoomOutVo createChatRoom(ChatRoomInVo chatRoomInVo, JwtPayload jwtPayload) throws BadRequestException {
         // 1. 데이터 검증
         checkChatRoomValidate(chatRoomInVo);
@@ -233,7 +231,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    @Transactional
     public ChatRoomOutVo updateChatRoom(String sessionId, ChatRoomInVo newChatRoomInVo, JwtPayload jwtPayload) throws BadRequestException {
 
         ChatRoomInVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomInVo.class);
@@ -248,7 +245,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
 
     @Override
-    @Transactional
     public boolean deleteChatRoom(String sessionId, JwtPayload jwtPayload, boolean isSystem) throws BadRequestException {
         if (!isSystem) {
             ChatRoomInVo redisChatRoom = redisUtils.getRedisDataByDataType(sessionId, DataType.CHATROOM, ChatRoomInVo.class);


### PR DESCRIPTION
chatroom 정보를 redis 에 저장함에 따라 아래 3가지 기능에서 rdb 관련 로직 제거
- 채팅방 생성
- 채팅방 업데이트
- 채팅방 삭제

## Sourcery 요약

채팅방을 위한 RDB (관계형 데이터베이스) 저장 로직을 제거하고, 완전한 Redis 기반 저장으로 전환합니다.

버그 수정:
- 불필요한 데이터베이스 쿼리 및 채팅방 저장 작업을 제거합니다.

개선 사항:
- Redis를 주요 저장 메커니즘으로 사용하여 채팅방 관리를 단순화합니다.

잡일:
- ChatRoomServiceImpl에서 ChatRoomRepository 의존성을 제거합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove RDB (Relational Database) storage logic for chat rooms, transitioning to full Redis-based storage

Bug Fixes:
- Remove redundant database queries and storage operations for chat rooms

Enhancements:
- Simplify chat room management by using Redis as the primary storage mechanism

Chores:
- Remove ChatRoomRepository dependency from ChatRoomServiceImpl

</details>