### PR TITLE
#39 채팅방 입장 시 currentUserCount 체크가 정상동작하지 않는 현상

### DIFF
--- a/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/chatforyou/io/services/impl/ChatRoomServiceImpl.java
@@ -141,7 +141,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
             throw new BadRequestException("Can not find ChatRoom");
         }
         // redis 에서 현재 유저 count 확인
-        int currentUserCount = redisUtils.getUserCount(sessionId);
+        int currentUserCount = redisUtils.getUserCount(sessionId) + 1;
         Integer maxUserCount = chatRoom.getMaxUserCount();
         if (maxUserCount < currentUserCount) {
             throw new BadRequestException("Max User count");


### PR DESCRIPTION
## Sourcery 요약

버그 수정:
- 최대 사용자 제한을 확인하기 전에 현재 사용자 수에 1을 더하여 사용자 수 계산을 수정했습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrected the user count calculation by adding 1 to the current user count before checking against the maximum user limit

</details>